### PR TITLE
Remove references to upstream CalebQ42

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # squashfs (WIP)
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/CalebQ42/squashfs)](https://pkg.go.dev/github.com/CalebQ42/squashfs) [![Go Report Card](https://goreportcard.com/badge/github.com/CalebQ42/squashfs)](https://goreportcard.com/report/github.com/CalebQ42/squashfs)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/sylabs/squashfs)](https://pkg.go.dev/github.com/sylabs/squashfs) [![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/squashfs)](https://goreportcard.com/report/github.com/sylabs/squashfs)
 
 A PURE Go library to read and write squashfs.
 
@@ -9,7 +9,7 @@ Currently has support for reading squashfs files and extracting files and folder
 Special thanks to <https://dr-emann.github.io/squashfs/> for some VERY important information in an easy to understand format.
 Thanks also to [distri's squashfs library](https://github.com/distr1/distri/tree/master/internal/squashfs) as I referenced it to figure some things out (and double check others).
 
-## [TODO](https://github.com/CalebQ42/squashfs/projects/1?fullscreen=true)
+## [TODO](https://github.com/sylabs/squashfs/projects/1?fullscreen=true)
 
 ## Limitations
 

--- a/fragment.go
+++ b/fragment.go
@@ -3,7 +3,7 @@ package squashfs
 import (
 	"io"
 
-	"github.com/CalebQ42/squashfs/internal/toreader"
+	"github.com/sylabs/squashfs/internal/toreader"
 )
 
 type fragEntry struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/CalebQ42/squashfs
+module github.com/sylabs/squashfs
 
 go 1.18
 

--- a/internal/data/fullreader.go
+++ b/internal/data/fullreader.go
@@ -3,8 +3,8 @@ package data
 import (
 	"io"
 
-	"github.com/CalebQ42/squashfs/internal/decompress"
-	"github.com/CalebQ42/squashfs/internal/toreader"
+	"github.com/sylabs/squashfs/internal/decompress"
+	"github.com/sylabs/squashfs/internal/toreader"
 )
 
 type FullReader struct {

--- a/internal/data/reader.go
+++ b/internal/data/reader.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/CalebQ42/squashfs/internal/decompress"
+	"github.com/sylabs/squashfs/internal/decompress"
 )
 
 type Reader struct {

--- a/internal/metadata/reader.go
+++ b/internal/metadata/reader.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/CalebQ42/squashfs/internal/decompress"
+	"github.com/sylabs/squashfs/internal/decompress"
 )
 
 type Reader struct {

--- a/reader.go
+++ b/reader.go
@@ -7,11 +7,11 @@ import (
 	"math"
 	"time"
 
-	"github.com/CalebQ42/squashfs/internal/decompress"
-	"github.com/CalebQ42/squashfs/internal/directory"
-	"github.com/CalebQ42/squashfs/internal/inode"
-	"github.com/CalebQ42/squashfs/internal/metadata"
-	"github.com/CalebQ42/squashfs/internal/toreader"
+	"github.com/sylabs/squashfs/internal/decompress"
+	"github.com/sylabs/squashfs/internal/directory"
+	"github.com/sylabs/squashfs/internal/inode"
+	"github.com/sylabs/squashfs/internal/metadata"
+	"github.com/sylabs/squashfs/internal/toreader"
 )
 
 type Reader struct {

--- a/reader_file.go
+++ b/reader_file.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/CalebQ42/squashfs/internal/directory"
-	"github.com/CalebQ42/squashfs/internal/inode"
+	"github.com/sylabs/squashfs/internal/directory"
+	"github.com/sylabs/squashfs/internal/inode"
 )
 
 //File represents a file inside a squashfs archive.

--- a/reader_fileinfo.go
+++ b/reader_fileinfo.go
@@ -4,8 +4,8 @@ import (
 	"io/fs"
 	"time"
 
-	"github.com/CalebQ42/squashfs/internal/directory"
-	"github.com/CalebQ42/squashfs/internal/inode"
+	"github.com/sylabs/squashfs/internal/directory"
+	"github.com/sylabs/squashfs/internal/inode"
 )
 
 type FileInfo struct {

--- a/reader_fs.go
+++ b/reader_fs.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/CalebQ42/squashfs/internal/directory"
-	"github.com/CalebQ42/squashfs/internal/inode"
+	"github.com/sylabs/squashfs/internal/directory"
+	"github.com/sylabs/squashfs/internal/inode"
 )
 
 //FS is a fs.FS representation of a squashfs directory.

--- a/reader_inode.go
+++ b/reader_inode.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"io"
 
-	"github.com/CalebQ42/squashfs/internal/data"
-	"github.com/CalebQ42/squashfs/internal/directory"
-	"github.com/CalebQ42/squashfs/internal/inode"
-	"github.com/CalebQ42/squashfs/internal/metadata"
-	"github.com/CalebQ42/squashfs/internal/toreader"
+	"github.com/sylabs/squashfs/internal/data"
+	"github.com/sylabs/squashfs/internal/directory"
+	"github.com/sylabs/squashfs/internal/inode"
+	"github.com/sylabs/squashfs/internal/metadata"
+	"github.com/sylabs/squashfs/internal/toreader"
 )
 
 func (r Reader) inodeFromRef(ref uint64) (i inode.Inode, err error) {


### PR DESCRIPTION
This fork currently requires a `replace` directive in each `go.mod` that it is referenced, e.g. in stereoscope, syft, and grype. In order to avoid this, it would be nice to just directly reference the fork as `github.com/sylabs/squashfs` to avoid a situation where the wrong dependencies are pulled in on account of missing the aforementioned replace directive.